### PR TITLE
Fix: Can now use palette_arr

### DIFF
--- a/src/midvoxio/models.py
+++ b/src/midvoxio/models.py
@@ -87,7 +87,7 @@ class RGBA():
     '''
     id=b'RGBA'
     def __init__(self,img_path=None,palette_arr=None):
-        if palette_arr:
+        if not palette_arr is None:
             self.palette_arr=palette_arr
         else:
             self.palette_arr=self._get_palette_arr_from_img(img_path)

--- a/src/midvoxio/voxio.py
+++ b/src/midvoxio/voxio.py
@@ -76,7 +76,7 @@ def write_list_to_vox(arr,vox_fname:str,palette_path=None,palette_arr=None):
     palette_path: if you want to use your own palette
     palette_arr: if you want to use your own palette
     '''
-    if palette_arr:
+    if not palette_arr is None:
         t=ArrayWriter(arr,palette_arr=palette_arr)
     elif palette_path:
         t=ArrayWriter(arr,palette_path=palette_path)

--- a/src/midvoxio/writer.py
+++ b/src/midvoxio/writer.py
@@ -9,7 +9,7 @@ class BaseWriter():
         self.chunks=[]
         if palette_path:
             self.rgba=RGBA(img_path=palette_path)
-        elif palette_arr:
+        elif not palette_arr is None:
             self.rgba=RGBA(palette_arr=palette_arr)
         else:
             raise Exception("palette missing")


### PR DESCRIPTION
Fix for ValueError that would occur when using the "palette_arr" parameter in various functions.

The error in question: 
`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`