### PR TITLE
Fix META chunk parsing crash

### DIFF
--- a/src/midvoxio/vox.py
+++ b/src/midvoxio/vox.py
@@ -118,6 +118,9 @@ class Chunk():
             # TODO: Warn user that we are skipping depracated chunk type
             pass
 
+        elif self.id == b'META':
+            # Skip META chunk to prevent error when parsing v200 format
+            pass
 
         else:
             raise ParsingException('Unknown chunk type: %s'%self.id)


### PR DESCRIPTION
When parsing v200 format .vox files, the parser would crash on encountering META chunks because they were not handled. Related to #10.