### PR TITLE
feat: add write support for nGRP and LAYR

### DIFF
--- a/src/midvoxio/models.py
+++ b/src/midvoxio/models.py
@@ -177,6 +177,7 @@ class NGRP():
     int32	: child node id
     }xN
     '''
+    id = b'nGRP'
     def __init__(self,node_id,dic,num,child_lst):
         self.node_id=node_id
         self.node_attr=dic
@@ -191,6 +192,13 @@ children_ids:{self.children_ids}
 '''
         return ret
 
+    def to_b(self):
+        byts = pack('i', self.node_id)
+        byts += Bdict(py_dict=self.node_attr).bytes
+        byts += pack('i', self.children_num)
+        for child_id in self.children_ids:
+            byts += pack('i', child_id)
+        return byts
 
 class nSHP():
     '''
@@ -283,10 +291,17 @@ class Layer():
             (_hidden : 0/1)
         int32	: reserved id, must be -1
     '''
+    id = b'LAYR'
     def __init__(self,id,dic,rev_id):
-        self.id=id
+        self.layer_id=id[0] if isinstance(id, tuple) else id
         self.dic=dic
-        self.rev_id=rev_id
+        self.rev_id=rev_id[0] if isinstance(rev_id, tuple) else rev_id
+
+    def to_b(self):
+        byts = pack('i', self.layer_id)
+        byts += Bdict(py_dict=self.dic).bytes
+        byts += pack('i', self.rev_id)
+        return byts
 
 class Note():
     '''


### PR DESCRIPTION
- Missing Serialization (to_b): The Layer and NGRP classes did not have the to_b() method. Without this, the library could read these chunks but could not write them back to a file.
- Attribute Name Collision (self.id): In the Layer class, the instance variable self.id (storing the integer Layer ID) was shadowing the class attribute id (which ChunkWriter expects to be the byte string b'LAYR'). This would cause the writer to fail or write invalid headers. Renaming it to self.layer_id (similar to nTRN.node_id) fixes this structural bug.
- Data Normalization: The parser (in vox.py) uses struct.unpack_from, which returns tuples (e.g., (0,)). The Layer class was storing these tuples directly. The writer requires integers. The update to __init__ handles this, ensuring the object is in a valid state whether created by the parser or manually.