### PR TITLE
Fix ArrayWriter palette mapping for transparent/last colors and add tests

### DIFF
--- a/src/midvoxio/writer.py
+++ b/src/midvoxio/writer.py
@@ -48,9 +48,19 @@ class ArrayWriter(BaseWriter):
         self.chunks=[self.size, self.xyzi, self.rgba]
     
     def mapping(self):
-        safepalette = np.array([UNSET, *self.rgba.palette_arr[:-1]], dtype=np.uint8)
+        palette_arr = np.asarray(self.rgba.palette_arr, dtype=np.uint8)
+        # Parsed RGBA chunks contain the 255 usable palette colors for color
+        # indexes 1..255. PNG palettes may provide a 256th sentinel color, so
+        # keep at most the first 255 colors and prepend color index 0 as empty.
+        safepalette = np.vstack([np.asarray(UNSET, dtype=np.uint8), palette_arr[:255]])
         bytepallet = np.frombuffer(safepalette.tobytes(), dtype=np.uint32)
-        d = {v: k for (k, v) in enumerate(bytepallet.tolist())}
+        d = {}
+        for k, v in enumerate(bytepallet.tolist()):
+            d.setdefault(v, k)
+
+        transparent = np.asarray(UNSET, dtype=np.uint8)
+        transparent_byte = np.frombuffer(transparent.tobytes(), dtype=np.uint32)[0]
+        d[transparent_byte] = 0
 
         flatvox = self.vox.reshape(-1, self.vox.shape[-1])
         flatbytes = np.frombuffer(flatvox.tobytes(), dtype=np.uint32)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,76 @@
+from struct import pack
+
+import numpy as np
+
+from midvoxio.models import XYZI
+from midvoxio.voxio import get_vox, vox_to_arr, write_list_to_vox
+from midvoxio.writer import ArrayWriter
+
+
+def test_transparent_palette_color_is_written_as_empty_space():
+    palette = _issue_palette()
+    arr = np.zeros((3, 1, 1, 4), dtype=float)
+    arr[0, 0, 0] = palette[93] / 255
+    arr[2, 0, 0] = palette[88] / 255
+
+    writer = ArrayWriter(arr, palette_arr=palette)
+
+    assert writer.xyzi.xyzi.tolist() == [[[94]], [[0]], [[89]]]
+    assert _written_voxels(writer.xyzi) == [
+        (0, 0, 0, 94),
+        (2, 0, 0, 89),
+    ]
+
+
+def test_issue_15_roundtrip_does_not_export_empty_cell_as_voxel(tmp_path):
+    src = tmp_path / "3x1.vox"
+    out = tmp_path / "3x1_out.vox"
+    src.write_bytes(_minimal_vox_file())
+
+    vox_arr = vox_to_arr(src, -1)
+    imported_palette = get_vox(src).palettes[0]
+    write_list_to_vox(vox_arr, out, palette_arr=imported_palette)
+
+    assert get_vox(src).voxels == [[(0, 0, 0, 94), (2, 0, 0, 89)]]
+    assert get_vox(out).voxels == [[(0, 0, 0, 94), (2, 0, 0, 89)]]
+
+
+def test_last_parsed_palette_color_can_be_written():
+    palette = np.zeros((255, 4), dtype=np.uint8)
+    palette[254] = [1, 2, 3, 255]
+
+    arr = np.zeros((1, 1, 1, 4), dtype=float)
+    arr[0, 0, 0] = palette[254] / 255
+
+    writer = ArrayWriter(arr, palette_arr=palette)
+
+    assert writer.xyzi.xyzi.tolist() == [[[255]]]
+    assert _written_voxels(writer.xyzi) == [(0, 0, 0, 255)]
+
+
+def _issue_palette():
+    palette = np.arange(255 * 4, dtype=np.uint8).reshape(255, 4)
+    palette[:, 3] = 255
+    palette[0] = [0, 0, 0, 0]
+    palette[88] = [10, 20, 30, 255]
+    palette[93] = [40, 50, 60, 255]
+    return palette
+
+
+def _minimal_vox_file():
+    palette = _issue_palette()
+    size = _chunk(b"SIZE", pack("3i", 3, 1, 1))
+    xyzi = _chunk(b"XYZI", pack("i", 2) + bytes([0, 0, 0, 94, 2, 0, 0, 89]))
+    rgba = _chunk(b"RGBA", palette.tobytes())
+    children = size + xyzi + rgba
+    return pack("4si", b"VOX ", 150) + pack("4sii", b"MAIN", 0, len(children)) + children
+
+
+def _chunk(chunk_id, content):
+    return pack("4sii", chunk_id, len(content), 0) + content
+
+
+def _written_voxels(xyzi: XYZI):
+    raw = xyzi.to_b()
+    count = np.frombuffer(raw[:4], dtype=np.int32)[0]
+    return [tuple(voxel) for voxel in np.frombuffer(raw[4:], dtype=np.uint8).reshape(count, 4)]


### PR DESCRIPTION
### Motivation

- Ensure palette color indexes map correctly when parsed RGBA palettes include a 256th sentinel or duplicate entries so transparent pixels become empty space.  
- Make the final parsed palette color (near index 255) writable and prevent it from being discarded or mis-mapped.  

### Description

- Update `ArrayWriter.mapping` to coerce `self.rgba.palette_arr` to `np.uint8`, keep at most the first 255 palette colors and prepend `UNSET` as color index `0`.  
- Build the color-to-index map using `setdefault` so the first occurrence of a color is preserved, and explicitly map the transparent `UNSET` byte to index `0`.  
- Convert palette rows to 32-bit words for fast lookup via `np.frombuffer` as before but ensure sentinel removal and stable mapping.  
- Add `tests/test_writer.py` with three tests: `test_transparent_palette_color_is_written_as_empty_space`, `test_issue_15_roundtrip_does_not_export_empty_cell_as_voxel`, and `test_last_parsed_palette_color_can_be_written` to cover transparent mapping, round-trip export, and the last-palette-color case.  

### Testing

- Ran the new test module with `pytest` which executed the three added tests.  
- All tests passed (3 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228a5b5f8083298f08b64493dca9f9)