### PR TITLE
Fix palette mapping and float->byte conversion; add tests for transparency and edge palette entries

### DIFF
--- a/src/midvoxio/writer.py
+++ b/src/midvoxio/writer.py
@@ -42,15 +42,25 @@ class ArrayWriter(BaseWriter):
     def __init__(self,vox_arr:np.ndarray,palette_path=None,palette_arr=None):
         super().__init__(palette_path, palette_arr)
 
-        self.vox=np.array(vox_arr*255, dtype=np.uint8)
+        self.vox=np.rint(np.asarray(vox_arr) * 255).astype(np.uint8)
         self.xyzi=XYZI(self.mapping())
         self.size=SIZE(vox_arr.shape)
         self.chunks=[self.size, self.xyzi, self.rgba]
     
     def mapping(self):
-        safepalette = np.array([UNSET, *self.rgba.palette_arr[:-1]], dtype=np.uint8)
+        palette_arr = np.asarray(self.rgba.palette_arr, dtype=np.uint8)
+        # Parsed RGBA chunks contain the 255 usable palette colors for color
+        # indexes 1..255. PNG palettes may provide a 256th sentinel color, so
+        # keep at most the first 255 colors and prepend color index 0 as empty.
+        safepalette = np.vstack([UNSET, palette_arr[:255]]).astype(np.uint8)
         bytepallet = np.frombuffer(safepalette.tobytes(), dtype=np.uint32)
-        d = {v: k for (k, v) in enumerate(bytepallet.tolist())}
+        d = {}
+        for k, v in enumerate(bytepallet.tolist()):
+            d.setdefault(v, k)
+
+        transparent = np.asarray(UNSET, dtype=np.uint8)
+        transparent_byte = np.frombuffer(transparent.tobytes(), dtype=np.uint32)[0]
+        d[transparent_byte] = 0
 
         flatvox = self.vox.reshape(-1, self.vox.shape[-1])
         flatbytes = np.frombuffer(flatvox.tobytes(), dtype=np.uint32)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from midvoxio.models import XYZI
+from midvoxio.voxio import get_vox, write_list_to_vox
+from midvoxio.writer import ArrayWriter
+
+
+def test_transparent_palette_color_is_written_as_empty_space():
+    palette = np.zeros((255, 4), dtype=np.uint8)
+    palette[0] = [0, 0, 0, 0]
+    palette[88] = [10, 20, 30, 255]
+    palette[93] = [40, 50, 60, 255]
+
+    arr = np.zeros((3, 1, 1, 4), dtype=float)
+    arr[0, 0, 0] = palette[93] / 255
+    arr[2, 0, 0] = palette[88] / 255
+
+    writer = ArrayWriter(arr, palette_arr=palette)
+
+    assert writer.xyzi.xyzi.tolist() == [[[94]], [[0]], [[89]]]
+    assert _written_voxels(writer.xyzi) == [
+        (0, 0, 0, 94),
+        (2, 0, 0, 89),
+    ]
+
+
+def test_issue_15_round_trip_keeps_middle_voxel_empty(tmp_path):
+    palette = np.zeros((255, 4), dtype=np.uint8)
+    palette[88] = [10, 20, 30, 255]
+    palette[93] = [40, 50, 60, 255]
+
+    arr = np.zeros((3, 1, 1, 4), dtype=float)
+    arr[0, 0, 0] = palette[93] / 255
+    arr[2, 0, 0] = palette[88] / 255
+
+    out = tmp_path / "3x1_out.vox"
+    write_list_to_vox(arr, str(out), palette_arr=palette)
+
+    assert get_vox(str(out)).voxels == [[(0, 0, 0, 94), (2, 0, 0, 89)]]
+
+
+def test_last_parsed_palette_color_can_be_written():
+    palette = np.zeros((255, 4), dtype=np.uint8)
+    palette[254] = [1, 2, 3, 255]
+
+    arr = np.zeros((1, 1, 1, 4), dtype=float)
+    arr[0, 0, 0] = palette[254] / 255
+
+    writer = ArrayWriter(arr, palette_arr=palette)
+
+    assert writer.xyzi.xyzi.tolist() == [[[255]]]
+    assert _written_voxels(writer.xyzi) == [(0, 0, 0, 255)]
+
+
+def _written_voxels(xyzi: XYZI):
+    raw = xyzi.to_b()
+    count = np.frombuffer(raw[:4], dtype=np.int32)[0]
+    return [tuple(voxel) for voxel in np.frombuffer(raw[4:], dtype=np.uint8).reshape(count, 4)]


### PR DESCRIPTION
### Motivation
- Prevent off-by-one and rounding issues when converting normalized RGBA floats to 0-255 bytes and ensure exact transparent pixels map to empty space. 
- Handle parsed palettes that include a 256th sentinel color from PNGs by restricting to the 255 usable colors and prepending the empty `UNSET` entry. 
- Ensure byte-wise palette lookup favors the first occurrence and explicitly maps the transparent sentinel to palette index `0`.

### Description
- Use `np.rint(np.asarray(vox_arr) * 255).astype(np.uint8)` for deterministic float-to-byte conversion in `ArrayWriter.__init__`. 
- In `ArrayWriter.mapping()` coerce `palette_arr` to `uint8`, keep at most the first 255 colors with `palette_arr[:255]`, and prepend `UNSET` via `np.vstack([UNSET, ...])`. 
- Build the byte->index mapping from `np.frombuffer(..., dtype=np.uint32)` while preserving the first seen index using `d.setdefault(...)`, and explicitly assign the transparent byte value to index `0`. 
- Small variable renames and restructuring to make byte conversions explicit and robust. 
- Add unit tests in `tests/test_writer.py` that cover transparent palette entries, an issue-specific round-trip case, and writing the last parsed palette color.

### Testing
- Added `tests/test_writer.py` containing three unit tests exercising transparency, round-trip behavior, and the final palette entry. 
- Ran `pytest tests/test_writer.py` and the three new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228a5b5f8083298f08b64493dca9f9)